### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/Celebr4tion/memory-engine/security/code-scanning/3](https://github.com/Celebr4tion/memory-engine/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository files.
- `security-events: write` for uploading SARIF files in the `security` job.

Each job can also have its own `permissions` block if specific jobs require additional permissions. However, for simplicity and maintainability, we will set the permissions at the root level, applying them to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
